### PR TITLE
feat: READMEに各コマンドの記入例を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,29 @@ kani key <COMMAND>
 
 **サブコマンド:**
 - `generate`: 新しい鍵を生成します
+
+  **入力例:**
+  ```
+  kani key generate
+  ```
 - `from-mnemonic`: ニーモニックから鍵を導出します (NIP-06)
+
+  **入力例:**
+  ```
+  kani key from-mnemonic "mnemonic phrase here"
+  ```
 - `encrypt`: パスワードで秘密鍵を暗号化します (NIP-49)
+
+  **入力例:**
+  ```
+  kani key encrypt --secret-key <nsec_secret_key> --password <password>
+  ```
 - `decrypt`: 暗号化された秘密鍵をパスワードで復号します (NIP-49)
+
+  **入力例:**
+  ```
+  kani key decrypt --encrypted-key <ncryptsec_encrypted_key> --password <password>
+  ```
 
 ### `event`
 イベント管理
@@ -27,12 +47,47 @@ kani event <COMMAND>
 
 **サブコマンド:**
 - `create-text-note`: テキスト投稿を作成します
+
+  **入力例:**
+  ```
+  kani event create-text-note --relay wss://relay.damus.io --secret-key <nsec_secret_key> "Hello, Nostr!"
+  ```
   - `--gift-wrap-recipient <npub>`: 指定した公開鍵の受信者でイベントをギフトラップします (NIP-59)
+
+  **入力例 (ギフトラップ):**
+  ```
+  kani event create-text-note --relay wss://relay.damus.io --secret-key <nsec_secret_key> --gift-wrap-recipient <npub_recipient_key> "This is a wrapped note"
+  ```
 - `create-dm`: ダイレクトメッセージを作成します (NIP-04)
+
+  **入力例:**
+  ```
+  kani event create-dm --relay wss://relay.damus.io --secret-key <nsec_secret_key> --recipient <npub_recipient_key> "Hello, secret world!"
+  ```
 - `get`: IDでイベントを取得します
+
+  **入力例:**
+  ```
+  kani event get --relay wss://relay.damus.io <note_event_id>
+  ```
 - `delete`: IDでイベントを削除します
-- `encrypt-payload`: ペイロードを暗号化します (NIP-44)
+
+  **入力例:**
+  ```
+  kani event delete --relay wss://relay.damus.io --secret-key <nsec_secret_key> <note_event_id_to_delete>
+  ```
+- `encrypt-payload`: ペイロードを暗о化します (NIP-44)
+
+  **入力例:**
+  ```
+  kani event encrypt-payload --secret-key <nsec_secret_key> --recipient <npub_recipient_key> "some sensitive data"
+  ```
 - `decrypt-payload`: ペイロードを復号します (NIP-44)
+
+  **入力例:**
+  ```
+  kani event decrypt-payload --secret-key <nsec_secret_key> --sender <npub_sender_key> <encrypted_payload>
+  ```
 
 ### `contact`
 コンタクトリスト管理
@@ -44,9 +99,29 @@ kani contact <COMMAND>
 
 **サブコマンド:**
 - `set`: コンタクトリストを設定します (NIP-02)
+
+  **入力例:**
+  ```
+  kani contact set --relay wss://relay.damus.io --secret-key <nsec_secret_key> <npub_key_1> <npub_key_2>
+  ```
 - `get`: コンタクトリストを取得します (NIP-02)
+
+  **入力例:**
+  ```
+  kani contact get --relay wss://relay.damus.io <npub_key>
+  ```
 - `set-relays`: リレーリストを設定します (NIP-65)
+
+  **入力例:**
+  ```
+  kani contact set-relays --relay wss://relay.damus.io --secret-key <nsec_secret_key> wss://relay.one#read wss://relay.two#write
+  ```
 - `get-relays`: リレーリストを取得します (NIP-65)
+
+  **入力例:**
+  ```
+  kani contact get-relays --relay wss://relay.damus.io --pubkey <npub_key>
+  ```
 
 ### `nip05`
 DNSベースの識別子 (NIP-05)
@@ -58,11 +133,13 @@ kani nip05 <COMMAND>
 **サブコマンド:**
 - `verify`: NIP-05識別子を検証します
 
-### `nip19`
-bech32エンコーディング (NIP-19)
-=======
-NIP-19 bech32エンコーディング
+  **入力例:**
+  ```
+  kani nip05 verify --nip05 user@example.com --pubkey <npub_key>
+  ```
 
+### `nip19`
+NIP-19 bech32エンコーディング
 
 **使用方法:**
 ```
@@ -71,8 +148,6 @@ kani nip19 <COMMAND>
 
 **サブコマンド:**
 - `encode`: エンティティをbech32形式にエンコードします
-
-=======
   - `npub`: 公開鍵をnpub形式にエンコードします
 
     **入力例:**
@@ -103,8 +178,12 @@ kani nip19 <COMMAND>
     ```
     kani nip19 encode nevent <hex_event_id> --author-pubkey <hex_public_key> --kind 1 wss://relay.one
     ```
-
 - `decode`: bech32文字列をデコードします
+
+  **入力例:**
+  ```
+  kani nip19 decode <bech32_string>
+  ```
 
 ### `nip46`
 Nostr Connect (NIP-46)
@@ -116,7 +195,17 @@ kani nip46 <COMMAND>
 
 **サブコマンド:**
 - `get-public-key`: リモート署名者から公開鍵を取得します
+
+  **入力例:**
+  ```
+  kani nip46 get-public-key "nostrconnect://<bunker_hex_pubkey>?relay=<relay_url>" --secret-key <local_nsec_key>
+  ```
 - `sign-event`: リモート署名者でイベントに署名します
+
+  **入力例:**
+  ```
+  kani nip46 sign-event "nostrconnect://<bunker_hex_pubkey>?relay=<relay_url>" --secret-key <local_nsec_key> '{"kind":1,"content":"...","tags":[],"created_at":...}'
+  ```
 
 ### `nip47`
 Nostr Wallet Connect (NIP-47)
@@ -128,8 +217,23 @@ kani nip47 <COMMAND>
 
 **サブコマンド:**
 - `get-info`: ウォレットから情報を取得します
+
+  **入力例:**
+  ```
+  kani nip47 get-info "nostr+walletconnect://<wallet_hex_pubkey>?relay=<relay_url>&secret=<hex_secret>"
+  ```
 - `get-balance`: ウォレットから残高を取得します
+
+  **入力例:**
+  ```
+  kani nip47 get-balance "nostr+walletconnect://<wallet_hex_pubkey>?relay=<relay_url>&secret=<hex_secret>"
+  ```
 - `pay-invoice`: ウォレットで請求書を支払います
+
+  **入力例:**
+  ```
+  kani nip47 pay-invoice "nostr+walletconnect://<wallet_hex_pubkey>?relay=<relay_url>&secret=<hex_secret>" <bolt11_invoice>
+  ```
 
 ### `uri`
 NIP-21 nostr URIのパース
@@ -137,4 +241,9 @@ NIP-21 nostr URIのパース
 **使用方法:**
 ```
 kani uri <URI>
+```
+
+**入力例:**
+```
+kani uri nostr:npub1...
 ```

--- a/src/cli/nip19.rs
+++ b/src/cli/nip19.rs
@@ -1,7 +1,6 @@
 use clap::{Parser, Subcommand};
 use nostr_sdk::prelude::*;
 use nostr_sdk::RelayUrl;
-use std::str::FromStr;
 
 #[derive(Parser)]
 pub struct Nip19Command {
@@ -70,6 +69,7 @@ pub async fn handle_nip19_command(command: Nip19Command) -> Result<(), Box<dyn s
     match command.subcommand {
         Nip19Subcommand::Decode { bech32_string } => {
             let decoded = Nip19::from_bech32(&bech32_string)?;
+            println!("{:#?}", decoded);
         }
         Nip19Subcommand::Encode(encode_command) => match encode_command.subcommand {
             EncodeSubcommand::Npub { hex_pubkey } => {
@@ -90,7 +90,7 @@ pub async fn handle_nip19_command(command: Nip19Command) -> Result<(), Box<dyn s
                 let profile = Nip19Profile::new(pubkey, relays_url);
                 println!("{}", profile.to_bech32()?);
             }
-            EncodeSubcommand::Nevent { hex_event_id, author_pubkey, relays } => {
+            EncodeSubcommand::Nevent { hex_event_id, author_pubkey, kind, relays } => {
                 let event_id = EventId::from_hex(&hex_event_id)?;
                 let author = match author_pubkey {
                     Some(hex) => Some(PublicKey::from_hex(&hex)?),
@@ -99,6 +99,7 @@ pub async fn handle_nip19_command(command: Nip19Command) -> Result<(), Box<dyn s
                 let relays_url = relays.into_iter().map(|r| RelayUrl::parse(&r)).collect::<Result<Vec<_>, _>>()?;
                 let mut event = Nip19Event::new(event_id);
                 event.author = author;
+                event.kind = kind.map(Kind::from);
                 event.relays = relays_url;
                 println!("{}", event.to_bech32()?);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod tests {
 
     #[test]
     fn test_parse_generate_command() {
-        let cli = Cli::try_parse_from(&["nostr-tool", "key", "generate"]).unwrap();
+        let _cli = Cli::try_parse_from(&["nostr-tool", "key", "generate"]).unwrap();
         // We can't easily test the subcommand matching in the new structure without making fields public.
         // For now, just parsing is a good enough smoke test.
     }


### PR DESCRIPTION
各コマンドとサブコマンドについて、具体的な使用方法を示す記入例を`README.md`に追加しました。

また、ドキュメントのフォーマットを修正し、テストで発生していたコンパイルエラーを修正しました。