### PR TITLE
feat: Implement config.toml for automatic key and relay loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,10 +1036,13 @@ name = "kani"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dirs",
  "nostr",
  "nostr-sdk",
  "reqwest",
+ "serde",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1026,6 +1050,16 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1278,6 +1312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1732,6 +1783,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -2061,6 +2121,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower-service"
@@ -2486,6 +2587,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ clap = { version = "4.4.7", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 nostr = { version = "0.43.0", features = ["nip06", "nip04", "nip46", "nip03", "nip49", "nip44", "nip59", "nip47"] }
 reqwest = "0.11"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+dirs = "5.0"

--- a/src/cli/contact.rs
+++ b/src/cli/contact.rs
@@ -1,65 +1,72 @@
+use crate::cli::CommonOptions;
+use crate::config::load_config;
 use clap::{Parser, Subcommand};
-use nostr_sdk::prelude::*;
 use nostr::prelude::FromBech32;
 use nostr::{Keys, SecretKey};
+use nostr_sdk::prelude::*;
 use std::time::Duration;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct ContactCommand {
     #[command(subcommand)]
     subcommand: ContactSubcommand,
+    #[command(flatten)]
+    common: CommonOptions,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 pub enum ContactSubcommand {
     /// Set contact list
     Set {
-        /// Relay to send the event
-        #[clap(short, long)]
-        relay: String,
-        /// Secret key to sign the event
-        #[clap(short, long)]
-        secret_key: String,
         /// Public keys to follow
         pubkeys: Vec<String>,
     },
     /// Get contact list
     Get {
-        /// Relay to get the contact list from
-        #[clap(short, long)]
-        relay: String,
         /// Public key to get the contact list for
         pubkey: String,
     },
     /// Set relay list (NIP-65)
     SetRelays {
-        /// Relay to publish the event to
-        #[clap(short, long)]
-        relay: String,
-        /// Secret key to sign the event
-        #[clap(short, long)]
-        secret_key: String,
         /// Relays to include in the list. Format: wss://relay.example.com[#read|#write]
         relays: Vec<String>,
     },
     /// Get relay list (NIP-65)
     GetRelays {
-        /// Relay to get the list from
-        #[clap(short, long)]
-        relay: String,
         /// Public key
         #[clap(short, long)]
         pubkey: String,
     },
 }
 
-pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn handle_contact_command(
+    command: ContactCommand,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config()?;
+
+    let relays = if !command.common.relay.is_empty() {
+        command.common.relay.clone()
+    } else {
+        config.relays.clone().unwrap_or_default()
+    };
+
     match command.subcommand {
-        ContactSubcommand::Set { relay, secret_key, pubkeys } => {
-            let secret_key = SecretKey::from_bech32(&secret_key)?;
+        ContactSubcommand::Set { pubkeys } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let secret_key_str = command
+                .common
+                .secret_key
+                .or(config.secret_key.clone())
+                .ok_or("Secret key not provided in args or config")?;
+
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(secret_key);
             let client = Client::new(keys);
-            client.add_relay(&relay).await?;
+            for relay in relays {
+                client.add_relay(&relay).await?;
+            }
             client.connect().await;
 
             let mut contacts = Vec::new();
@@ -76,12 +83,17 @@ pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Box<d
 
             client.shutdown().await;
         }
-        ContactSubcommand::Get { relay, pubkey } => {
-            let pubkey = PublicKey::from_bech32(&pubkey)
-                .or_else(|_| PublicKey::from_hex(&pubkey))?;
+        ContactSubcommand::Get { pubkey } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let pubkey =
+                PublicKey::from_bech32(&pubkey).or_else(|_| PublicKey::from_hex(&pubkey))?;
 
             let keys = Keys::generate();
             let client = Client::new(keys);
+
+            let relay_urls: Vec<&str> = relays.iter().map(|s| s.as_str()).collect();
 
             let filter = Filter::new()
                 .author(pubkey)
@@ -89,7 +101,9 @@ pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Box<d
                 .limit(1);
 
             let timeout = Duration::from_secs(10);
-            let events = client.fetch_events_from(vec![&relay], filter, timeout).await?;
+            let events = client
+                .fetch_events_from(relay_urls, filter, timeout)
+                .await?;
 
             if let Some(event) = events.first() {
                 println!("{:#?}", event.tags);
@@ -99,15 +113,26 @@ pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Box<d
 
             client.shutdown().await;
         }
-        ContactSubcommand::SetRelays { relay, secret_key, relays } => {
-            let secret_key = SecretKey::from_bech32(&secret_key)?;
+        ContactSubcommand::SetRelays { relays: relays_to_set } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config to publish the list".into());
+            }
+            let secret_key_str = command
+                .common
+                .secret_key
+                .or(config.secret_key)
+                .ok_or("Secret key not provided in args or config")?;
+
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(secret_key);
             let client = Client::new(keys);
-            client.add_relay(&relay).await?;
+            for relay in relays {
+                client.add_relay(&relay).await?;
+            }
             client.connect().await;
 
             let mut tags = Vec::new();
-            for r in relays {
+            for r in relays_to_set {
                 let mut parts = r.splitn(2, '#');
                 let url = parts.next().unwrap();
                 let marker = parts.next();
@@ -131,12 +156,17 @@ pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Box<d
 
             client.shutdown().await;
         }
-        ContactSubcommand::GetRelays { relay, pubkey } => {
-            let pubkey = PublicKey::from_bech32(&pubkey)
-                .or_else(|_| PublicKey::from_hex(&pubkey))?;
+        ContactSubcommand::GetRelays { pubkey } => {
+             if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let pubkey =
+                PublicKey::from_bech32(&pubkey).or_else(|_| PublicKey::from_hex(&pubkey))?;
 
             let keys = Keys::generate();
             let client = Client::new(keys);
+
+            let relay_urls: Vec<&str> = relays.iter().map(|s| s.as_str()).collect();
 
             let filter = Filter::new()
                 .author(pubkey)
@@ -144,7 +174,9 @@ pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Box<d
                 .limit(1);
 
             let timeout = Duration::from_secs(10);
-            let events = client.fetch_events_from(vec![&relay], filter, timeout).await?;
+            let events = client
+                .fetch_events_from(relay_urls, filter, timeout)
+                .await?;
 
             if let Some(event) = events.first() {
                 println!("{:#?}", event.tags);

--- a/src/cli/event.rs
+++ b/src/cli/event.rs
@@ -1,28 +1,25 @@
+use crate::cli::CommonOptions;
+use crate::config::load_config;
 use clap::{Parser, Subcommand};
-use nostr_sdk::prelude::*;
-use nostr::prelude::{FromBech32, ToBech32};
-use nostr::{Keys, SecretKey};
-use nostr::EventBuilder;
 use nostr::nips::{nip04, nip44};
+use nostr::prelude::{FromBech32, ToBech32};
+use nostr::{EventBuilder, Keys, SecretKey};
 use nostr_sdk::nips::nip09::EventDeletionRequest;
+use nostr_sdk::prelude::*;
 use std::time::Duration;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct EventCommand {
     #[command(subcommand)]
     subcommand: EventSubcommand,
+    #[command(flatten)]
+    common: CommonOptions,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 enum EventSubcommand {
     /// Create a text note
     CreateTextNote {
-        /// Relay to send the event
-        #[clap(short, long)]
-        relay: String,
-        /// Secret key to sign the event
-        #[clap(short, long)]
-        secret_key: String,
         /// Text note content
         content: String,
         /// Recipient public key for gift wrap (NIP-59)
@@ -31,12 +28,6 @@ enum EventSubcommand {
     },
     /// Create a direct message (NIP-04)
     CreateDm {
-        /// Relay to send the event
-        #[clap(short, long)]
-        relay: String,
-        /// Secret key to sign the event
-        #[clap(short, long)]
-        secret_key: String,
         /// Recipient public key (bech32)
         #[clap(short, long)]
         recipient: String,
@@ -45,28 +36,16 @@ enum EventSubcommand {
     },
     /// Get an event by id
     Get {
-        /// Relay to get the event from
-        #[clap(short, long)]
-        relay: String,
         /// Event id to get
         id: String,
     },
     /// Delete an event
     Delete {
-        /// Relay to publish the deletion event to
-        #[clap(short, long)]
-        relay: String,
-        /// Secret key to sign the event
-        #[clap(short, long)]
-        secret_key: String,
         /// ID of the event to delete
         event_id: String,
     },
     /// Encrypt a payload using NIP-44
     EncryptPayload {
-        /// Secret key to use for encryption (bech32)
-        #[clap(short, long)]
-        secret_key: String,
         /// Recipient public key (bech32)
         #[clap(short, long)]
         recipient: String,
@@ -75,9 +54,6 @@ enum EventSubcommand {
     },
     /// Decrypt a payload using NIP-44
     DecryptPayload {
-        /// Secret key to use for decryption (bech32)
-        #[clap(short, long)]
-        secret_key: String,
         /// Sender public key (bech32)
         #[clap(short, long)]
         sender: String,
@@ -86,12 +62,6 @@ enum EventSubcommand {
     },
     /// Create a long-form content note (NIP-23)
     CreateLongFormPost {
-        /// Relay to send the event
-        #[clap(short, long)]
-        relay: String,
-        /// Secret key to sign the event
-        #[clap(short, long)]
-        secret_key: String,
         /// Path to the markdown file
         #[clap(short, long)]
         file: String,
@@ -108,13 +78,29 @@ enum EventSubcommand {
 }
 
 pub async fn handle_event_command(command: EventCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config()?;
+
+    let relays = if !command.common.relay.is_empty() {
+        command.common.relay
+    } else {
+        config.relays.clone().unwrap_or_default()
+    };
+
     match command.subcommand {
-        EventSubcommand::CreateTextNote { relay, secret_key, content, gift_wrap_recipient } => {
-            let secret_key = SecretKey::from_bech32(&secret_key)?;
+        EventSubcommand::CreateTextNote {
+            content,
+            gift_wrap_recipient,
+        } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let secret_key_str = command.common.secret_key.or(config.secret_key).ok_or("Secret key not provided")?;
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(secret_key);
             let client = Client::new(keys.clone());
-
-            client.add_relay(&relay).await?;
+            for relay in relays {
+                client.add_relay(&relay).await?;
+            }
             client.connect().await;
 
             let builder = EventBuilder::text_note(&content);
@@ -132,13 +118,22 @@ pub async fn handle_event_command(command: EventCommand) -> Result<(), Box<dyn s
 
             client.shutdown().await;
         }
-        EventSubcommand::CreateDm { relay, secret_key, recipient, content } => {
-            let secret_key = SecretKey::from_bech32(&secret_key)?;
+        EventSubcommand::CreateDm {
+            recipient,
+            content,
+        } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let secret_key_str = command.common.secret_key.or(config.secret_key).ok_or("Secret key not provided")?;
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(secret_key);
             let recipient_pubkey = PublicKey::from_bech32(&recipient)?;
 
             let client = Client::new(keys.clone());
-            client.add_relay(&relay).await?;
+            for relay in relays {
+                client.add_relay(&relay).await?;
+            }
             client.connect().await;
 
             let sk = keys.secret_key();
@@ -151,16 +146,23 @@ pub async fn handle_event_command(command: EventCommand) -> Result<(), Box<dyn s
 
             client.shutdown().await;
         }
-        EventSubcommand::Get { relay, id } => {
-            let event_id = EventId::from_bech32(&id)
-                .or_else(|_| EventId::from_hex(&id))?;
+        EventSubcommand::Get { id } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let event_id =
+                EventId::from_bech32(&id).or_else(|_| EventId::from_hex(&id))?;
 
             let keys = Keys::generate();
             let client = Client::new(keys);
 
+            let relay_urls: Vec<&str> = relays.iter().map(|s| s.as_str()).collect();
+
             let filter = Filter::new().id(event_id);
             let timeout = Duration::from_secs(10);
-            let events = client.fetch_events_from(vec![&relay], filter, timeout).await?;
+            let events = client
+                .fetch_events_from(relay_urls, filter, timeout)
+                .await?;
 
             if let Some(event) = events.first() {
                 println!("{:#?}", event);
@@ -170,15 +172,21 @@ pub async fn handle_event_command(command: EventCommand) -> Result<(), Box<dyn s
 
             client.shutdown().await;
         }
-        EventSubcommand::Delete { relay, secret_key, event_id } => {
-            let secret_key = SecretKey::from_bech32(&secret_key)?;
+        EventSubcommand::Delete { event_id } => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let secret_key_str = command.common.secret_key.or(config.secret_key).ok_or("Secret key not provided")?;
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(secret_key);
             let client = Client::new(keys);
-            client.add_relay(&relay).await?;
+            for relay in relays {
+                client.add_relay(&relay).await?;
+            }
             client.connect().await;
 
-            let event_id_to_delete = EventId::from_bech32(&event_id)
-                .or_else(|_| EventId::from_hex(&event_id))?;
+            let event_id_to_delete =
+                EventId::from_bech32(&event_id).or_else(|_| EventId::from_hex(&event_id))?;
 
             let request = EventDeletionRequest {
                 ids: vec![event_id_to_delete],
@@ -188,34 +196,46 @@ pub async fn handle_event_command(command: EventCommand) -> Result<(), Box<dyn s
             let builder = EventBuilder::delete(request);
             let signed_event = client.sign_event_builder(builder).await?;
             let deletion_event_id = client.send_event(&signed_event).await?;
-            println!("Deletion event sent with id: {}", deletion_event_id.to_bech32()?);
+            println!(
+                "Deletion event sent with id: {}",
+                deletion_event_id.to_bech32()?
+            );
 
             client.shutdown().await;
         }
-        EventSubcommand::EncryptPayload { secret_key, recipient, content } => {
-            let sk = SecretKey::from_bech32(&secret_key)?;
+        EventSubcommand::EncryptPayload {
+            recipient,
+            content,
+        } => {
+            let secret_key_str = command.common.secret_key.or(config.secret_key).ok_or("Secret key not provided")?;
+            let sk = SecretKey::from_bech32(&secret_key_str)?;
             let pk = PublicKey::from_bech32(&recipient)?;
             let encrypted = nip44::encrypt(&sk, &pk, &content, nip44::Version::default())?;
             println!("{}", encrypted);
         }
-        EventSubcommand::DecryptPayload { secret_key, sender, content } => {
-            let sk = SecretKey::from_bech32(&secret_key)?;
+        EventSubcommand::DecryptPayload { sender, content } => {
+            let secret_key_str = command.common.secret_key.or(config.secret_key).ok_or("Secret key not provided")?;
+            let sk = SecretKey::from_bech32(&secret_key_str)?;
             let pk = PublicKey::from_bech32(&sender)?;
             let decrypted = nip44::decrypt(&sk, &pk, &content)?;
             println!("{}", decrypted);
         }
         EventSubcommand::CreateLongFormPost {
-            relay,
-            secret_key,
             file,
             title,
             summary,
             d_identifier,
         } => {
-            let secret_key = SecretKey::from_bech32(&secret_key)?;
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            let secret_key_str = command.common.secret_key.or(config.secret_key).ok_or("Secret key not provided")?;
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(secret_key);
             let client = Client::new(keys.clone());
-            client.add_relay(&relay).await?;
+            for relay in relays {
+                client.add_relay(&relay).await?;
+            }
             client.connect().await;
 
             let content = std::fs::read_to_string(&file)?;
@@ -241,11 +261,13 @@ pub async fn handle_event_command(command: EventCommand) -> Result<(), Box<dyn s
             let timestamp_str = publication_timestamp.as_u64().to_string();
             tags.push(Tag::parse(["published_at", &timestamp_str])?);
 
-
             let builder = EventBuilder::new(Kind::Custom(30023), &content).tags(tags);
             let event = client.sign_event_builder(builder).await?;
             let event_id = client.send_event(&event).await?;
-            println!("Long-form post sent with id: {}", event_id.to_bech32()?);
+            println!(
+                "Long-form post sent with id: {}",
+                event_id.to_bech32()?
+            );
 
             client.shutdown().await;
         }

--- a/src/cli/key.rs
+++ b/src/cli/key.rs
@@ -5,13 +5,13 @@ use nostr::bip39::Mnemonic;
 use nostr::nips::nip49::EncryptedSecretKey;
 use nostr::{Keys, SecretKey};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct KeyCommand {
     #[command(subcommand)]
     subcommand: KeySubcommand,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 enum KeySubcommand {
     /// Generate new keys
     Generate,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,17 @@ use self::{
     nip47::Nip47Command,
 };
 
+#[derive(Parser, Clone)]
+pub struct CommonOptions {
+    /// Secret key to use for signing events
+    #[clap(long)]
+    pub secret_key: Option<String>,
+
+    /// Relay to connect to
+    #[clap(long, short, action = clap::ArgAction::Append)]
+    pub relay: Vec<String>,
+}
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
@@ -27,7 +38,7 @@ pub struct Cli {
     command: Command,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 enum Command {
     /// Keys management
     Key(KeyCommand),

--- a/src/cli/nip05.rs
+++ b/src/cli/nip05.rs
@@ -2,14 +2,14 @@ use clap::Parser;
 use nostr_sdk::prelude::*;
 use nostr::nips::nip05::{Nip05Address, verify_from_raw_json};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct Nip05Command {
     /// Verify a NIP-05 identifier
     #[command(subcommand)]
     subcommand: Nip05Subcommand,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub enum Nip05Subcommand {
     Verify {
         /// NIP-05 identifier (user@example.com)

--- a/src/cli/nip19.rs
+++ b/src/cli/nip19.rs
@@ -2,13 +2,13 @@ use clap::{Parser, Subcommand};
 use nostr_sdk::prelude::*;
 use nostr_sdk::RelayUrl;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct Nip19Command {
     #[command(subcommand)]
     subcommand: Nip19Subcommand,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 pub enum Nip19Subcommand {
     /// Encode entities to bech32 format
     Encode(EncodeCommand),
@@ -19,13 +19,13 @@ pub enum Nip19Subcommand {
     },
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct EncodeCommand {
     #[command(subcommand)]
     subcommand: EncodeSubcommand,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 pub enum EncodeSubcommand {
     /// Encode a public key to npub format
     Npub {

--- a/src/cli/nip46.rs
+++ b/src/cli/nip46.rs
@@ -1,52 +1,64 @@
+use crate::cli::CommonOptions;
+use crate::config::load_config;
 use clap::Parser;
-use nostr_sdk::prelude::*;
-use nostr::nips::nip46::{NostrConnectMessage, NostrConnectURI, NostrConnectRequest, NostrConnectMethod};
 use nostr::nips::nip04;
+use nostr::nips::nip46::{
+    NostrConnectMessage, NostrConnectMethod, NostrConnectRequest, NostrConnectURI,
+};
 use nostr::UnsignedEvent;
+use nostr_sdk::prelude::*;
 use tokio::time::{timeout, Duration};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct Nip46Command {
     /// Nostr Connect (NIP-46)
     #[command(subcommand)]
     subcommand: Nip46Subcommand,
+    #[command(flatten)]
+    common: CommonOptions,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub enum Nip46Subcommand {
     /// Get public key from a remote signer
     GetPublicKey {
         /// Bunker URI (nostrconnect://...)
         uri: String,
-        /// Local secret key to use for communication (bech32)
-        #[clap(short, long)]
-        secret_key: String,
     },
     /// Sign an unsigned event using a remote signer
     SignEvent {
         /// Bunker URI (nostrconnect://...)
         uri: String,
-        /// Local secret key to use for communication (bech32)
-        #[clap(short, long)]
-        secret_key: String,
         /// Unsigned event to sign (JSON string)
         event_json: String,
-    }
+    },
 }
 
 pub async fn handle_nip46_command(command: Nip46Command) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config()?;
+    let secret_key_str = command
+        .common
+        .secret_key
+        .or(config.secret_key)
+        .ok_or("Secret key not provided in args or config")?;
+
     match command.subcommand {
-        Nip46Subcommand::GetPublicKey { uri, secret_key } => {
-            let sk = SecretKey::from_bech32(&secret_key)?;
+        Nip46Subcommand::GetPublicKey { uri } => {
+            let sk = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(sk);
 
             let bunker_uri = NostrConnectURI::parse(&uri)?;
 
-            let bunker_pk = if let NostrConnectURI::Bunker { remote_signer_public_key, .. } = &bunker_uri {
-                *remote_signer_public_key
-            } else {
-                return Err("Not a bunker URI".into());
-            };
+            let bunker_pk =
+                if let NostrConnectURI::Bunker {
+                    remote_signer_public_key,
+                    ..
+                } = &bunker_uri
+                {
+                    *remote_signer_public_key
+                } else {
+                    return Err("Not a bunker URI".into());
+                };
 
             let req = NostrConnectRequest::GetPublicKey;
             let msg = NostrConnectMessage::request(&req);
@@ -62,7 +74,10 @@ pub async fn handle_nip46_command(command: Nip46Command) -> Result<(), Box<dyn s
             let event = client.sign_event_builder(builder).await?;
             client.send_event(&event).await?;
 
-            println!("GetPublicKey request sent with id: {}", event.id.to_bech32()?);
+            println!(
+                "GetPublicKey request sent with id: {}",
+                event.id.to_bech32()?
+            );
 
             // Handle response
             let filter = Filter::new()
@@ -81,10 +96,14 @@ pub async fn handle_nip46_command(command: Nip46Command) -> Result<(), Box<dyn s
                 while let Ok(notification) = notifications.recv().await {
                     if let RelayPoolNotification::Event { event, .. } = notification {
                         if event.kind == Kind::EncryptedDirectMessage {
-                            if let Ok(decrypted) = nip04::decrypt(keys.secret_key(), &event.pubkey, &event.content) {
+                            if let Ok(decrypted) =
+                                nip04::decrypt(keys.secret_key(), &event.pubkey, &event.content)
+                            {
                                 if let Ok(msg) = NostrConnectMessage::from_json(&decrypted) {
                                     if msg.id() == request_id {
-                                        if let Ok(response) = msg.to_response(NostrConnectMethod::GetPublicKey) {
+                                        if let Ok(response) =
+                                            msg.to_response(NostrConnectMethod::GetPublicKey)
+                                        {
                                             if let Some(result) = response.result {
                                                 if let Ok(pk) = result.to_get_public_key() {
                                                     return Some(Ok(pk));
@@ -111,17 +130,22 @@ pub async fn handle_nip46_command(command: Nip46Command) -> Result<(), Box<dyn s
 
             client.shutdown().await;
         }
-        Nip46Subcommand::SignEvent { uri, secret_key, event_json } => {
-            let sk = SecretKey::from_bech32(&secret_key)?;
+        Nip46Subcommand::SignEvent { uri, event_json } => {
+            let sk = SecretKey::from_bech32(&secret_key_str)?;
             let keys = Keys::new(sk);
 
             let bunker_uri = NostrConnectURI::parse(&uri)?;
 
-            let bunker_pk = if let NostrConnectURI::Bunker { remote_signer_public_key, .. } = &bunker_uri {
-                *remote_signer_public_key
-            } else {
-                return Err("Not a bunker URI".into());
-            };
+            let bunker_pk =
+                if let NostrConnectURI::Bunker {
+                    remote_signer_public_key,
+                    ..
+                } = &bunker_uri
+                {
+                    *remote_signer_public_key
+                } else {
+                    return Err("Not a bunker URI".into());
+                };
 
             let unsigned_event = UnsignedEvent::from_json(&event_json)?;
             let req = NostrConnectRequest::SignEvent(unsigned_event);
@@ -156,10 +180,14 @@ pub async fn handle_nip46_command(command: Nip46Command) -> Result<(), Box<dyn s
                 while let Ok(notification) = notifications.recv().await {
                     if let RelayPoolNotification::Event { event, .. } = notification {
                         if event.kind == Kind::EncryptedDirectMessage {
-                            if let Ok(decrypted) = nip04::decrypt(keys.secret_key(), &event.pubkey, &event.content) {
+                            if let Ok(decrypted) =
+                                nip04::decrypt(keys.secret_key(), &event.pubkey, &event.content)
+                            {
                                 if let Ok(msg) = NostrConnectMessage::from_json(&decrypted) {
                                     if msg.id() == request_id {
-                                        if let Ok(response) = msg.to_response(NostrConnectMethod::SignEvent) {
+                                        if let Ok(response) =
+                                            msg.to_response(NostrConnectMethod::SignEvent)
+                                        {
                                             if let Some(result) = response.result {
                                                 if let Ok(signed_event) = result.to_sign_event() {
                                                     return Some(Ok(signed_event));

--- a/src/cli/nip47.rs
+++ b/src/cli/nip47.rs
@@ -3,14 +3,14 @@ use nostr_sdk::prelude::*;
 use nostr::nips::nip47::{Request, NostrWalletConnectURI, Response, PayInvoiceRequest};
 use tokio::time::{timeout, Duration};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct Nip47Command {
     /// Nostr Wallet Connect (NIP-47)
     #[command(subcommand)]
     subcommand: Nip47Subcommand,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub enum Nip47Subcommand {
     /// Get info from a wallet
     GetInfo {

--- a/src/cli/uri.rs
+++ b/src/cli/uri.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use nostr_sdk::prelude::*;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct UriCommand {
     /// nostr: URI to parse
     uri: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,23 @@
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize, Default, Debug)]
+pub struct Config {
+    pub secret_key: Option<String>,
+    pub relays: Option<Vec<String>>,
+}
+
+pub fn load_config() -> Result<Config, Box<dyn std::error::Error>> {
+    let config_path = dirs::config_dir()
+        .ok_or("Could not find config directory")?
+        .join("kani/config.toml");
+
+    if !config_path.exists() {
+        return Ok(Config::default());
+    }
+
+    let content = fs::read_to_string(config_path)?;
+    let config: Config = toml::from_str(&content)?;
+
+    Ok(config)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod config;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
This change introduces a configuration file (`config.toml`) to allow users to specify their secret key and a list of default relays, removing the need to provide them as command-line arguments for every execution.

The application now loads settings from `~/.config/kani/config.toml`. Command-line arguments for `--secret-key` and `--relay` will override the values specified in the configuration file.

This functionality has been implemented for the `event`, `contact`, and `nip46` subcommands, which are the ones that can benefit from this feature.