### PR TITLE
feat: Add a command to show the config file path

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,25 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Clone)]
+pub struct ConfigCommand {
+    #[command(subcommand)]
+    command: ConfigSubCommand,
+}
+
+#[derive(Subcommand, Clone)]
+enum ConfigSubCommand {
+    /// Show the path to the config file
+    Path,
+}
+
+pub async fn handle_config_command(
+    config_command: ConfigCommand,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match config_command.command {
+        ConfigSubCommand::Path => {
+            let path = crate::config::get_config_path()?;
+            println!("{}", path.display());
+        }
+    }
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod uri;
 pub mod nip05;
 pub mod nip46;
 pub mod nip47;
+pub mod config;
 
 use self::{
     contact::ContactCommand,
@@ -18,6 +19,7 @@ use self::{
     nip05::Nip05Command,
     nip46::Nip46Command,
     nip47::Nip47Command,
+    config::ConfigCommand,
 };
 
 #[derive(Parser, Clone)]
@@ -56,6 +58,8 @@ enum Command {
     Nip46(Nip46Command),
     /// NIP-47 Nostr Wallet Connect
     Nip47(Nip47Command),
+    /// Config management
+    Config(ConfigCommand),
 }
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -70,6 +74,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::Nip05(nip05_command) => nip05::handle_nip05_command(nip05_command).await?,
         Command::Nip46(nip46_command) => nip46::handle_nip46_command(nip46_command).await?,
         Command::Nip47(nip47_command) => nip47::handle_nip47_command(nip47_command).await?,
+        Command::Config(config_command) => config::handle_config_command(config_command).await?,
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::fs;
+use std::path::PathBuf;
 
 #[derive(Deserialize, Default, Debug)]
 pub struct Config {
@@ -7,10 +8,14 @@ pub struct Config {
     pub relays: Option<Vec<String>>,
 }
 
+pub fn get_config_path() -> Result<PathBuf, &'static str> {
+    dirs::config_dir()
+        .ok_or("Could not find config directory")
+        .map(|p| p.join("kani/config.toml"))
+}
+
 pub fn load_config() -> Result<Config, Box<dyn std::error::Error>> {
-    let config_path = dirs::config_dir()
-        .ok_or("Could not find config directory")?
-        .join("kani/config.toml");
+    let config_path = get_config_path()?;
 
     if !config_path.exists() {
         return Ok(Config::default());


### PR DESCRIPTION
This commit adds a new subcommand `config path` that displays the path to the configuration file.

The implementation includes:
- A new `get_config_path` function in `src/config.rs` to centralize the logic for determining the config path.
- A new `config` subcommand module in `src/cli/config.rs`.
- Integration of the new command into the main CLI in `src/cli/mod.rs`.