### PR TITLE
feat: Add edit-profile command with robust template generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "nostr-sdk",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ tokio = { version = "1.0", features = ["full"] }
 nostr = { version = "0.43.0", features = ["nip06", "nip04", "nip46", "nip03", "nip49", "nip44", "nip59", "nip47"] }
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.8"
 dirs = "5.0"


### PR DESCRIPTION
This commit introduces a new `edit-profile` subcommand to the `event` command and includes enhancements based on user feedback and debugging.

This command allows users to edit their Nostr profile metadata (Kind 0) using their preferred text editor.

Key features and fixes:
- Fetches the user's current profile from configured relays.
- If no profile exists, or if the existing profile's content is empty ("{}"), it generates a template with placeholder values for common fields (name, about, picture, etc.) to guide the user. This fixes a bug where templates were not shown for keys with an empty profile event.
- The profile is written to a temporary `profile.json` file for editing.
- The user's default editor (`$EDITOR`) is opened to edit this file.
- After editing, the updated profile is read, and a new `Kind 0` event is created, signed, and sent to the relays.

This provides a convenient and user-friendly way for users to manage their Nostr identity from the command line.