### PR TITLE
feat: Add `contact edit-relays` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 dirs = "5.0"
+tempfile = "3.10.1"

--- a/src/cli/contact.rs
+++ b/src/cli/contact.rs
@@ -4,6 +4,10 @@ use clap::{Parser, Subcommand};
 use nostr::prelude::FromBech32;
 use nostr::{Keys, SecretKey};
 use nostr_sdk::prelude::*;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::process::Command as StdCommand;
 use std::time::Duration;
 
 #[derive(Parser, Clone)]
@@ -37,6 +41,8 @@ pub enum ContactSubcommand {
         #[clap(short, long)]
         pubkey: String,
     },
+    /// Edit relay list (NIP-65) in your editor
+    EditRelays,
 }
 
 pub async fn handle_contact_command(
@@ -183,6 +189,99 @@ pub async fn handle_contact_command(
             } else {
                 println!("Relay list not found.");
             }
+
+            client.shutdown().await;
+        }
+        ContactSubcommand::EditRelays => {
+            if relays.is_empty() {
+                return Err("No relays provided in args or config".into());
+            }
+            // Get keys
+            let secret_key_str = command
+                .common
+                .secret_key
+                .or(config.secret_key)
+                .ok_or("Secret key not provided in args or config")?;
+            let secret_key = SecretKey::from_bech32(&secret_key_str)?;
+            let keys = Keys::new(secret_key);
+            let client = Client::new(keys.clone());
+
+            // Add relays and connect
+            for relay in &relays {
+                client.add_relay(relay.clone()).await?;
+            }
+            client.connect().await;
+
+            // Fetch existing relay list
+            let filter = Filter::new()
+                .author(keys.public_key())
+                .kind(Kind::RelayList)
+                .limit(1);
+            let timeout = Duration::from_secs(10);
+            let relay_urls: Vec<&str> = relays.iter().map(|s| s.as_str()).collect();
+            let events = client
+                .fetch_events_from(relay_urls, filter, timeout)
+                .await?;
+
+            let mut current_relays_str = String::new();
+            if let Some(event) = events.first() {
+                for tag in event.tags.iter() {
+                    let tag_vec = tag.clone().to_vec();
+                    if tag_vec.get(0).map(|s| s.as_str()) == Some("r") {
+                        if let Some(url) = tag_vec.get(1) {
+                            current_relays_str.push_str(url);
+                            if let Some(marker) = tag_vec.get(2) {
+                                if marker == "read" || marker == "write" {
+                                    current_relays_str.push_str(&format!(" #{}", marker));
+                                }
+                            }
+                            current_relays_str.push('\n');
+                        }
+                    }
+                }
+            }
+
+            // Create and write to temp file
+            let mut temp_file = tempfile::NamedTempFile::new()?;
+            temp_file.write_all(current_relays_str.as_bytes())?;
+
+            // Open editor
+            let editor = env::var("EDITOR").unwrap_or_else(|_| "vim".to_string());
+            let status = StdCommand::new(editor)
+                .arg(temp_file.path())
+                .status()?;
+
+            if !status.success() {
+                return Err("Editor exited with a non-zero status.".into());
+            }
+
+            // Read from temp file
+            let new_relays_str = fs::read_to_string(temp_file.path())?;
+
+            // Parse new relays
+            let mut tags = Vec::new();
+             for line in new_relays_str.lines().filter(|l| !l.trim().is_empty()) {
+                let mut parts = line.splitn(2, '#');
+                let url = parts.next().unwrap().trim();
+                let marker = parts.next().map(|s| s.trim());
+
+                let tag_vec = if let Some(m) = marker {
+                    if m == "read" || m == "write" {
+                        vec!["r".to_string(), url.to_string(), m.to_string()]
+                    } else {
+                        vec!["r".to_string(), url.to_string()]
+                    }
+                } else {
+                    vec!["r".to_string(), url.to_string()]
+                };
+                tags.push(Tag::parse(&tag_vec)?);
+            }
+
+            // Publish new event using the same connected client
+            let builder = EventBuilder::new(Kind::RelayList, "").tags(tags);
+            let event = client.sign_event_builder(builder).await?;
+            client.send_event(&event).await?;
+            println!("Relay list updated.");
 
             client.shutdown().await;
         }


### PR DESCRIPTION
This commit introduces a new subcommand `contact edit-relays` that allows users to edit their NIP-65 relay list using their default system editor.

The command performs the following actions:
1. Connects to the user's configured relays.
2. Fetches the user's current kind:10002 (relay list) event.
3. Writes the list of relays to a temporary file in a human-readable format.
4. Opens the user's `$EDITOR` to allow them to modify the file.
5. Reads the updated file contents.
6. Parses the new list and constructs a new NIP-65 event.
7. Publishes the updated event to the connected relays.