### PR TITLE
feat(cli): Update edit-relays template with examples

### DIFF
--- a/src/cli/contact.rs
+++ b/src/cli/contact.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 use nostr::prelude::FromBech32;
 use nostr::{Keys, SecretKey};
 use nostr_sdk::prelude::*;
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -223,27 +224,63 @@ pub async fn handle_contact_command(
                 .fetch_events_from(relay_urls, filter, timeout)
                 .await?;
 
-            let mut current_relays_str = String::new();
+            let mut relay_markers: HashMap<String, Vec<String>> = HashMap::new();
             if let Some(event) = events.first() {
                 for tag in event.tags.iter() {
                     let tag_vec = tag.clone().to_vec();
                     if tag_vec.get(0).map(|s| s.as_str()) == Some("r") {
                         if let Some(url) = tag_vec.get(1) {
-                            current_relays_str.push_str(url);
+                            let markers = relay_markers.entry(url.clone()).or_default();
                             if let Some(marker) = tag_vec.get(2) {
-                                if marker == "read" || marker == "write" {
-                                    current_relays_str.push_str(&format!(" #{}", marker));
-                                }
+                                markers.push(marker.clone());
                             }
-                            current_relays_str.push('\n');
                         }
                     }
                 }
             }
 
+            let mut current_relays_str = String::new();
+            for (url, markers) in relay_markers {
+                current_relays_str.push_str(&url);
+                for marker in markers {
+                    current_relays_str.push_str(&format!(" #{}", marker));
+                }
+                current_relays_str.push('\n');
+            }
+
+            let template = r#"# Read — これによりリレーはプライベート／非表示の受信箱になります。受信箱のように機能しますが、そのように宣伝されることはありません。kaniはこのリレーであなたを参照するイベントを探します。
+#   (例: wss://relay.example.com #read)
+# Inbox — Readと同様ですが、他のクライアントがこのリレーにあなたをタグ付けしたイベントを送信できるように宣伝されます。これを3つか4つ持つことをお勧めします。
+#   (例: wss://relay.example.com #Inbox)
+# Write — これによりリレーはプライベート／非表示の送信箱になります。送信箱のように機能しますが、そのように宣伝されることはありません。kaniはここにあなたのイベントを投稿します。
+#   (例: wss://relay.example.com #write)
+# Outbox — Writeと同様ですが、他のクライアントがこのリレーからあなたのイベントを取得できるように宣伝されます。これを3つから5つ持つことをお勧めします。
+#   (例: wss://relay.example.com #Outbox)
+# Discover — この設定はリレーが他の人のリレーリストを見つけるために使われることを意味します。
+#   (例: wss://relay.example.com #Discover)
+# Spam Safe — 特定のスパム設定を使う場合、このリレーをスパムフィルターとして信頼することを意味し、Gossipはこのリレーから誰の返信も取得します（あなたがフォローしている人だけではなく）。
+#   (例: wss://relay.example.com #Spam Safe)
+# Direct Message — これは受信箱のようなものですが、DM専用です。
+#   (例: wss://relay.example.com #Direct Message)
+# Global feed — グローバルフィードを表示するとき、このリレーからのイベントも含まれます。選択するリレーが多いほど、グローバルフィードは賑やかになります。
+#   (例: wss://relay.example.com #Global feed)
+# Search — Search Relaysを実行するとき、その検索はこのリレーに送信されます。これをいくつか持つことも、非常に良いリレーを見つけた場合は1つだけ持つこともできます。
+#   (例: wss://relay.example.com #Search)
+#
+# --- リレーの例 ---
+# wss://relay.damus.io #read #write
+# wss://relay.snort.social #read #write
+# wss://nostr.wine #read #write
+"#;
+
+            let mut file_content = String::new();
+            file_content.push_str(template);
+            file_content.push_str("\n");
+            file_content.push_str(&current_relays_str);
+
             // Create and write to temp file
             let mut temp_file = tempfile::NamedTempFile::new()?;
-            temp_file.write_all(current_relays_str.as_bytes())?;
+            temp_file.write_all(file_content.as_bytes())?;
 
             // Open editor
             let editor = env::var("EDITOR").unwrap_or_else(|_| "vim".to_string());
@@ -260,21 +297,29 @@ pub async fn handle_contact_command(
 
             // Parse new relays
             let mut tags = Vec::new();
-             for line in new_relays_str.lines().filter(|l| !l.trim().is_empty()) {
-                let mut parts = line.splitn(2, '#');
-                let url = parts.next().unwrap().trim();
-                let marker = parts.next().map(|s| s.trim());
+            for line in new_relays_str.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
 
-                let tag_vec = if let Some(m) = marker {
-                    if m == "read" || m == "write" {
-                        vec!["r".to_string(), url.to_string(), m.to_string()]
-                    } else {
-                        vec!["r".to_string(), url.to_string()]
-                    }
+                let mut parts = line.split('#');
+                let url = parts.next().unwrap().trim();
+                if url.is_empty() {
+                    continue;
+                }
+                let markers: Vec<&str> =
+                    parts.map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+
+                if markers.is_empty() {
+                    let tag_vec = vec!["r".to_string(), url.to_string()];
+                    tags.push(Tag::parse(&tag_vec)?);
                 } else {
-                    vec!["r".to_string(), url.to_string()]
-                };
-                tags.push(Tag::parse(&tag_vec)?);
+                    for m in markers {
+                        let tag_vec = vec!["r".to_string(), url.to_string(), m.to_string()];
+                        tags.push(Tag::parse(&tag_vec)?);
+                    }
+                }
             }
 
             // Publish new event using the same connected client


### PR DESCRIPTION
This change updates the template for the `contact edit-relays` command based on user feedback.

- Translates "Example Relays" to Japanese ("リレーの例").
- Adds a commented-out example configuration for each relay type described in the template to make it easier for users to get started.