### PR TITLE
feat: NIP-04の削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ kani event <COMMAND>
   ```
   kani event create-text-note --relay wss://relay.damus.io --secret-key <nsec_secret_key> --gift-wrap-recipient <npub_recipient_key> "This is a wrapped note"
   ```
-- `create-dm`: ダイレクトメッセージを作成します (NIP-04)
-
-  **入力例:**
-  ```
-  kani event create-dm --relay wss://relay.damus.io --secret-key <nsec_secret_key> --recipient <npub_recipient_key> "Hello, secret world!"
-  ```
 - `get`: IDでイベントを取得します
 
   **入力例:**

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,9 +59,6 @@ pub enum Error {
     #[error("NIP-47 error: {0}")]
     Nip47(#[from] nostr::nips::nip47::Error),
 
-    #[error("NIP-04 error: {0}")]
-    Nip04(#[from] nostr::nips::nip04::Error),
-
     #[error("NIP-44 error: {0}")]
     Nip44(#[from] nostr::nips::nip44::Error),
 


### PR DESCRIPTION
非推奨となったNIP-04関連の機能を削除します。

- `event` コマンドから `create-dm` サブコマンドを削除
- `EventSubcommand` enum から `CreateDm` を削除
- `Error` enum から `Nip04` を削除
- `README.md` から `create-dm` の説明を削除