### PR TITLE
feat: Add onboarding wizard for new users

### DIFF
--- a/src/cli/event.rs
+++ b/src/cli/event.rs
@@ -181,7 +181,7 @@ async fn create_text_note(
     Ok(())
 }
 
-async fn edit_profile(secret_key_str: String, relays: Vec<String>) -> Result<(), Error> {
+pub async fn edit_profile(secret_key_str: String, relays: Vec<String>) -> Result<(), Error> {
     let keys = Keys::new(SecretKey::from_bech32(&secret_key_str)?);
     let client = connect_client(keys.clone(), relays.clone()).await?;
 

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -65,7 +65,7 @@ pub async fn handle_relay_command(command: RelayCommand) -> Result<(), Error> {
     Ok(())
 }
 
-async fn edit_relays(secret_key_str: String, relays: Vec<String>) -> Result<(), Error> {
+pub async fn edit_relays(secret_key_str: String, relays: Vec<String>) -> Result<(), Error> {
     let keys = Keys::new(SecretKey::from_bech32(&secret_key_str)?);
     let client = connect_client(keys.clone(), relays.clone()).await?;
 


### PR DESCRIPTION
This commit introduces an onboarding wizard to guide new users through the initial setup process after key generation.

A `--wizard` flag has been added to the `key generate` command. When this flag is used, the application will interactively prompt the user to:
1. Set up their profile (name, about, picture, etc.).
2. Configure their relay list.

This feature improves the user experience for those new to Nostr, helping them get started more easily.

To achieve this, the `edit_profile` and `edit_relays` functions were made public, and the `key generate` command handler was updated to orchestrate the new workflow.