### PR TITLE
feat: Add option to save encrypted secret key in wizard

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,24 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Deserialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug)]
 pub struct Config {
     pub secret_key: Option<String>,
     pub relays: Option<Vec<String>>,
+    pub encrypted_secret_key: Option<String>,
 }
 
 use crate::error::Error;
 
 pub fn get_config_path() -> Result<PathBuf, Error> {
-    dirs::config_dir()
+    let path = dirs::config_dir()
         .ok_or(Error::Message(
             "Could not find config directory".to_string(),
-        ))
-        .map(|p| p.join("kani/config.toml"))
+        ))?
+        .join("kani");
+    fs::create_dir_all(&path)?;
+    Ok(path.join("config.toml"))
 }
 
 pub fn load_config() -> Result<Config, Error> {
@@ -29,4 +32,11 @@ pub fn load_config() -> Result<Config, Error> {
     let config: Config = toml::from_str(&content)?;
 
     Ok(config)
+}
+
+pub fn save_config(config: &Config) -> Result<(), Error> {
+    let config_path = get_config_path()?;
+    let content = toml::to_string(config)?;
+    fs::write(config_path, content)?;
+    Ok(())
 }


### PR DESCRIPTION
This change adds a new step to the key generation wizard (`key generate --wizard`).

After the existing profile and relay setup prompts, it now asks the user if they want to save their secret key to the `config.toml` file.

If the user agrees, it prompts for a password and saves the NIP-49 encrypted secret key to the configuration file.