### PR TITLE
feat: 入力バリデーションをリレーおよびプロフィールURLに追加

### DIFF
--- a/src/cli/event.rs
+++ b/src/cli/event.rs
@@ -239,6 +239,13 @@ pub async fn edit_profile(secret_key_str: String, relays: Vec<String>) -> Result
         Input::with_theme(&theme)
             .with_prompt("Picture URL")
             .with_initial_text(current_metadata.picture.unwrap_or_default())
+            .validate_with(|input: &String| -> Result<(), &str> {
+                if input.is_empty() || input.starts_with("http://") || input.starts_with("https://") {
+                    Ok(())
+                } else {
+                    Err("URLはhttp://またはhttps://で始まる必要があります。")
+                }
+            })
             .interact_text()?,
     );
 
@@ -246,6 +253,13 @@ pub async fn edit_profile(secret_key_str: String, relays: Vec<String>) -> Result
         Input::with_theme(&theme)
             .with_prompt("Banner URL")
             .with_initial_text(current_metadata.banner.unwrap_or_default())
+            .validate_with(|input: &String| -> Result<(), &str> {
+                if input.is_empty() || input.starts_with("http://") || input.starts_with("https://") {
+                    Ok(())
+                } else {
+                    Err("URLはhttp://またはhttps://で始まる必要があります。")
+                }
+            })
             .interact_text()?,
     );
 
@@ -253,6 +267,13 @@ pub async fn edit_profile(secret_key_str: String, relays: Vec<String>) -> Result
         Input::with_theme(&theme)
             .with_prompt("Website URL")
             .with_initial_text(current_metadata.website.unwrap_or_default())
+            .validate_with(|input: &String| -> Result<(), &str> {
+                if input.is_empty() || input.starts_with("http://") || input.starts_with("https://") {
+                    Ok(())
+                } else {
+                    Err("URLはhttp://またはhttps://で始まる必要があります。")
+                }
+            })
             .interact_text()?,
     );
 

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -127,6 +127,13 @@ pub async fn edit_relays(secret_key_str: String, relays: Vec<String>) -> Result<
                 let new_url: String = Input::with_theme(&theme)
                     .with_prompt("リレーURL")
                     .with_initial_text(url_to_edit)
+                    .validate_with(|input: &String| -> Result<(), &str> {
+                        if input.starts_with("wss://") {
+                            Ok(())
+                        } else {
+                            Err("リレーURLはwss://で始まる必要があります。")
+                        }
+                    })
                     .interact_text()?;
 
                 let marker_options = &[
@@ -166,6 +173,13 @@ pub async fn edit_relays(secret_key_str: String, relays: Vec<String>) -> Result<
                 // Add new relay
                 let url: String = Input::with_theme(&theme)
                     .with_prompt("新しいリレーURL")
+                    .validate_with(|input: &String| -> Result<(), &str> {
+                        if input.starts_with("wss://") {
+                            Ok(())
+                        } else {
+                            Err("リレーURLはwss://で始まる必要があります。")
+                        }
+                    })
                     .interact_text()?;
                 if url.is_empty() {
                     continue;


### PR DESCRIPTION
リレーとプロフィールの編集を行う対話型ウィザードに入力バリデーションを追加します。

- リレーURLが`wss://`で始まることを検証するようになりました。これは`relay edit`コマンドで新しいリレーを追加または既存のリレーを編集する際に適用されます。
- プロフィールURL（画像、バナー、ウェブサイト）が`http://`または`https://`で始まることを検証するようになりました。値をクリアするために空の入力も許可されます。これは`event edit-profile`コマンドで適用されます。

これにより、よくある間違いを捕捉し、データが期待される形式に準拠していることを保証することで、ユーザーエクスペリエンスが向上します。