### PR TITLE
feat: Add session-based login and logout commands

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -3,6 +3,22 @@ use crate::config::Config;
 use crate::error::Error;
 use nostr_sdk::{Client, Keys};
 
+pub fn get_secret_key(
+    common_opts: &CommonOptions,
+    config: &Config,
+) -> Result<String, Error> {
+    if let Some(sk) = &common_opts.secret_key {
+        return Ok(sk.clone());
+    }
+    if let Ok(sk) = std::env::var("NOSTR_SECRET_KEY") {
+        return Ok(sk);
+    }
+    if let Some(sk) = &config.secret_key {
+        return Ok(sk.clone());
+    }
+    Err(Error::SecretKeyMissing)
+}
+
 pub fn get_relays(common_opts: &CommonOptions, config: &Config) -> Vec<String> {
     if !common_opts.relay.is_empty() {
         common_opts.relay.clone()

--- a/src/cli/contact.rs
+++ b/src/cli/contact.rs
@@ -1,5 +1,5 @@
 use crate::cli::CommonOptions;
-use crate::cli::common::{connect_client, get_relays};
+use crate::cli::common::{connect_client, get_relays, get_secret_key};
 use crate::config::load_config;
 use clap::{Parser, Subcommand};
 use nostr::prelude::FromBech32;
@@ -37,11 +37,7 @@ pub async fn handle_contact_command(command: ContactCommand) -> Result<(), Error
 
     match command.subcommand {
         ContactSubcommand::Add { pubkeys } => {
-            let secret_key_str = command
-                .common
-                .secret_key
-                .or(config.secret_key.clone())
-                .ok_or(Error::SecretKeyMissing)?;
+            let secret_key_str = get_secret_key(&command.common, &config)?;
             set_contact_list(pubkeys, secret_key_str, relays).await?;
         }
         ContactSubcommand::List { pubkey } => {

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -1,0 +1,34 @@
+use crate::config::load_config;
+use crate::error::Error;
+use clap::Parser;
+use dialoguer::Password;
+use nostr::nips::nip49::EncryptedSecretKey;
+use nostr::prelude::{FromBech32, ToBech32};
+
+#[derive(Parser, Clone)]
+pub struct LoginCommand {}
+
+pub async fn handle_login_command(_command: LoginCommand) -> Result<(), Error> {
+    let config = load_config()?;
+
+    let encrypted_key_bech32 = config.encrypted_secret_key.ok_or(Error::Message(
+        "No encrypted secret key found in config. Please run `key generate --wizard` or `key encrypt` first.".to_string(),
+    ))?;
+
+    let password = Password::new()
+        .with_prompt("Enter password to decrypt secret key")
+        .interact()?;
+
+    let encrypted_key = EncryptedSecretKey::from_bech32(&encrypted_key_bech32)?;
+    let secret_key = encrypted_key.decrypt(&password)?;
+
+    println!(
+        "export NOSTR_SECRET_KEY={}",
+        secret_key.to_bech32().unwrap()
+    );
+    // stderr message to the user so it doesn't get captured by eval
+    eprintln!("Login successful. Key is now available in your shell environment.");
+    eprintln!("Run `eval $(kani-nostr-cli logout)` to clear the key.");
+
+    Ok(())
+}

--- a/src/cli/logout.rs
+++ b/src/cli/logout.rs
@@ -1,0 +1,12 @@
+use crate::error::Error;
+use clap::Parser;
+
+#[derive(Parser, Clone)]
+pub struct LogoutCommand {}
+
+pub async fn handle_logout_command(_command: LogoutCommand) -> Result<(), Error> {
+    println!("unset NOSTR_SECRET_KEY");
+    // stderr message to the user so it doesn't get captured by eval
+    eprintln!("Logout successful. Key has been cleared from your shell environment.");
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,8 @@ pub mod config;
 pub mod contact;
 pub mod event;
 pub mod key;
+pub mod login;
+pub mod logout;
 pub mod nip05;
 pub mod nip19;
 pub mod nip46;
@@ -14,8 +16,8 @@ pub mod uri;
 
 use self::{
     config::ConfigCommand, contact::ContactCommand, event::EventCommand, key::KeyCommand,
-    nip05::Nip05Command, nip19::Nip19Command, nip46::Nip46Command, nip47::Nip47Command,
-    relay::RelayCommand, uri::UriCommand,
+    login::LoginCommand, logout::LogoutCommand, nip05::Nip05Command, nip19::Nip19Command,
+    nip46::Nip46Command, nip47::Nip47Command, relay::RelayCommand, uri::UriCommand,
 };
 
 #[derive(Parser, Clone)]
@@ -38,6 +40,10 @@ pub struct Cli {
 
 #[derive(Subcommand, Clone)]
 enum Command {
+    /// Decrypts secret key and loads it into the shell environment
+    Login(LoginCommand),
+    /// Clears the decrypted secret key from the shell environment
+    Logout(LogoutCommand),
     /// Keys management
     Key(KeyCommand),
     /// Event management
@@ -66,6 +72,8 @@ pub async fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Login(login_command) => login::handle_login_command(login_command).await?,
+        Command::Logout(logout_command) => logout::handle_logout_command(logout_command).await?,
         Command::Key(key_command) => key::handle_key_command(key_command).await?,
         Command::Event(event_command) => event::handle_event_command(event_command).await?,
         Command::Contact(contact_command) => {

--- a/src/cli/nip46.rs
+++ b/src/cli/nip46.rs
@@ -1,3 +1,4 @@
+use crate::cli::common::get_secret_key;
 use crate::cli::CommonOptions;
 use crate::config::load_config;
 use clap::Parser;
@@ -38,11 +39,7 @@ use crate::error::Error;
 
 pub async fn handle_nip46_command(command: Nip46Command) -> Result<(), Error> {
     let config = load_config()?;
-    let secret_key_str = command
-        .common
-        .secret_key
-        .or(config.secret_key)
-        .ok_or(Error::SecretKeyMissing)?;
+    let secret_key_str = get_secret_key(&command.common, &config)?;
 
     match command.subcommand {
         Nip46Subcommand::GetPublicKey { uri } => {

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -1,4 +1,4 @@
-use crate::cli::common::{connect_client, get_relays};
+use crate::cli::common::{connect_client, get_relays, get_secret_key};
 use crate::cli::CommonOptions;
 use crate::config::load_config;
 use crate::error::Error;
@@ -43,22 +43,14 @@ pub async fn handle_relay_command(command: RelayCommand) -> Result<(), Error> {
         RelaySubcommand::Set {
             relays: relays_to_set,
         } => {
-            let secret_key_str = command
-                .common
-                .secret_key
-                .or(config.secret_key)
-                .ok_or(Error::SecretKeyMissing)?;
+            let secret_key_str = get_secret_key(&command.common, &config)?;
             set_relays(relays_to_set, secret_key_str, relays).await?;
         }
         RelaySubcommand::Get { pubkey } => {
             get_relays_list(pubkey, relays).await?;
         }
         RelaySubcommand::Edit => {
-            let secret_key_str = command
-                .common
-                .secret_key
-                .or(config.secret_key)
-                .ok_or(Error::SecretKeyMissing)?;
+            let secret_key_str = get_secret_key(&command.common, &config)?;
             edit_relays(secret_key_str, relays).await?;
         }
     }


### PR DESCRIPTION
This commit refactors the authentication mechanism to be session-based, improving security and convenience.

The `login` command now prompts the user for a password to decrypt the NIP-49 encrypted secret key stored in the configuration file. It then prints an `export` command to load the decrypted key into the `NOSTR_SECRET_KEY` environment variable for the current shell session. This is intended to be used with `eval $(kani-nostr-cli login)`.

A corresponding `logout` command has been added to print the `unset` command, clearing the key from the environment.

All commands requiring a secret key have been refactored to use a new `get_secret_key` helper function. This function prioritizes retrieving the key in the following order:
1.  The `--secret-key` command-line argument.
2.  The `NOSTR_SECRET_KEY` environment variable.
3.  The plaintext `secret_key` field in the config file.

This new workflow prevents the decrypted secret key from being stored on disk and automatically clears it when the terminal session ends.